### PR TITLE
Enable model validation notebook in production and staging environments

### DIFF
--- a/mlops-poc/terraform/prod/training-job.tf
+++ b/mlops-poc/terraform/prod/training-job.tf
@@ -54,7 +54,7 @@ resource "databricks_job" "model_training_job" {
         # `enabled`  : Run the model validation notebook. Move model to Production stage only if all model validation
         #               rules are passing.
         # TODO: update run_mode
-        run_mode = "disabled"
+        run_mode = "enabled"
         # Whether to load the current registered "Production" stage model as baseline.
         # Baseline model is a requirement for relative change and absolute change validation thresholds.
         # TODO: update enable_baseline_comparison

--- a/mlops-poc/terraform/staging/training-job.tf
+++ b/mlops-poc/terraform/staging/training-job.tf
@@ -50,7 +50,7 @@ resource "databricks_job" "model_training_job" {
         # `enabled`  : Run the model validation notebook. Move model to Production stage only if all model validation
         #               rules are passing.
         # TODO: update run_mode
-        run_mode = "disabled"
+        run_mode = "enabled"
         # Whether to load the current registered "Production" stage model as baseline.
         # Baseline model is a requirement for relative change and absolute change validation thresholds.
         # TODO: update enable_baseline_comparison


### PR DESCRIPTION
Changed `run_mode` from "disabled" to "enabled" in both production and staging training-job.tf files. This ensures that the model validation notebook runs in both environments and that the model moves to the Production stage only if all validation rules are passing.