### PR TITLE
Train without feature store

### DIFF
--- a/.github/workflows/autofill-pr.yml
+++ b/.github/workflows/autofill-pr.yml
@@ -1,0 +1,12 @@
+name: Autofill PR description
+
+on: pull_request
+
+jobs:
+  openai-pr-description:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: platisd/openai-pr-description@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/run-tests-fs.yml
+++ b/.github/workflows/run-tests-fs.yml
@@ -1,266 +1,266 @@
-name: Feature and Training Integration Tests for mlops-poc
-on:
-  workflow_dispatch:
-  pull_request:
-    paths-ignore:
-      - "mlops-poc/terraform/**"
+# name: Feature and Training Integration Tests for mlops-poc
+# on:
+#   workflow_dispatch:
+#   pull_request:
+#     paths-ignore:
+#       - "mlops-poc/terraform/**"
 
-env:
-  DATABRICKS_HOST: https://adb-1778171230779412.12.azuredatabricks.net
-  DATABRICKS_JOBS_API_VERSION: 2.1
-  NODE_TYPE_ID: Standard_D3_v2
+# env:
+#   DATABRICKS_HOST: https://adb-1778171230779412.12.azuredatabricks.net
+#   DATABRICKS_JOBS_API_VERSION: 2.1
+#   NODE_TYPE_ID: Standard_D3_v2
 
-concurrency: mlops-poc-feature-training-integration-test-staging
+# concurrency: mlops-poc-feature-training-integration-test-staging
 
-jobs:
-  unit_tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      # Feature store tests bring up a local Spark session, so Java is required.
-      - uses: actions/setup-java@v2
-        with:
-          distribution: "temurin"
-          java-version: "11"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r test-requirements.txt
-      - name: Run tests with pytest
-        run: |
-          cd mlops-poc
-          pytest
-          cd ..
+# jobs:
+#   unit_tests:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v2
+#       - uses: actions/setup-python@v2
+#         with:
+#           python-version: 3.9
+#       # Feature store tests bring up a local Spark session, so Java is required.
+#       - uses: actions/setup-java@v2
+#         with:
+#           distribution: "temurin"
+#           java-version: "11"
+#       - name: Install dependencies
+#         run: |
+#           python -m pip install --upgrade pip
+#           pip install -r requirements.txt
+#           pip install -r test-requirements.txt
+#       - name: Run tests with pytest
+#         run: |
+#           cd mlops-poc
+#           pytest
+#           cd ..
 
-  integration_test:
-    needs: unit_tests
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-      - name: GET Databricks AAD Token
-        run: |
-          DATABRICKS_TOKEN=$(curl --fail -X POST -H 'Content-Type: application/x-www-form-urlencoded' \
-                                              "https://login.microsoftonline.com/${{ secrets.stagingAzureSpTenantId }}/oauth2/v2.0/token" \
-                                              -d "client_id=${{ secrets.stagingAzureSpApplicationId }}" \
-                                              -d 'grant_type=client_credentials' \
-                                              -d 'scope=2ff814a6-3304-4ab8-85cb-cd0e6f879c1d%2F.default' \
-                                              -d "client_secret=${{ secrets.stagingAzureSpClientSecret }}" |  jq -r  '.access_token')
-          echo "DATABRICKS_TOKEN=$DATABRICKS_TOKEN" >> "$GITHUB_ENV"
-          echo "$DATABRICKS_TOKEN"
+#   integration_test:
+#     needs: unit_tests
+#     runs-on: ubuntu-20.04
+#     steps:
+#       - name: Checkout repo
+#         uses: actions/checkout@v3
+#       - name: GET Databricks AAD Token
+#         run: |
+# DATABRICKS_TOKEN=$(curl --fail -X POST -H 'Content-Type: application/x-www-form-urlencoded' \
+#                                     "https://login.microsoftonline.com/${{ secrets.stagingAzureSpTenantId }}/oauth2/v2.0/token" \
+#                                     -d "client_id=${{ secrets.stagingAzureSpApplicationId }}" \
+#                                     -d 'grant_type=client_credentials' \
+#                                     -d 'scope=2ff814a6-3304-4ab8-85cb-cd0e6f879c1d%2F.default' \
+#                                     -d "client_secret=${{ secrets.stagingAzureSpClientSecret }}" |  jq -r  '.access_token')
+# echo "DATABRICKS_TOKEN=$DATABRICKS_TOKEN" >> "$GITHUB_ENV"
+#           echo "$DATABRICKS_TOKEN"
 
-      # - name: read workspace id
-      #   id: workspace
-      #   run: echo "::set-output name=id::$(cat workspaces.json | jq -c '.workspaces[] | select(.name == "My Workspace").id')"
-      # - name: Generate AAD Token
-      #   run: ./.github/workflows/scripts/generate-aad-token.sh ${{ secrets.stagingAzureSpTenantId }} ${{ secrets.stagingAzureSpApplicationId }} ${{ secrets.stagingAzureSpClientSecret }}
-      # This step populates a JSON Databricks job payload that will be submitted as an integration test run.
-      # It currently builds a one-off multi-task job that contains feature engineering tasks to populate Feature
-      # Store tables, and a training task that uses those tables.
-      # You will need to modify the contents below to fit your pipelines (both # of tasks and input parameters for each
-      # task).
-      - name: Build JSON job payload for integration test
-        uses: actions/github-script@v6
-        id: integration-test-content
-        with:
-          # TODO update the tasks and notebook parameters below to match your integration test setup.
-          script: |
-            const output = `
-                    {
-            "run_name": "features-training-integration-test",
-            "tasks": [
-              {
-                "task_key": "pickup-features",
-                "notebook_task": {
-                  "notebook_path": "mlops-poc/feature_engineering/notebooks/GenerateAndWriteFeatures", 
-                  "base_parameters": {
-                    "input_table_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled",
-                    "timestamp_column": "tpep_pickup_datetime",
-                    "output_table_name": "feature_store_taxi_example.trip_pickup_features_test",
-                    "features_transform_module": "pickup_features",
-                    "primary_keys": "zip"
-                  }
-                },
-                "new_cluster": {
-                  "spark_version": "12.2.x-cpu-ml-scala2.12",
-                  "node_type_id": "${{ env.NODE_TYPE_ID }}",
-                  "num_workers": 0,
-                  "spark_conf": {
-                    "spark.databricks.cluster.profile": "singleNode",
-                    "spark.master": "local[*, 4]"
-                  },
-                  "custom_tags": {
-                    "ResourceClass": "SingleNode",
-                    "clusterSource": "mlops-stack/0.0"
-                  }
-                }
-              },
-              {
-                "task_key": "dropoff-features",
-                "notebook_task": {
-                  "notebook_path": "mlops-poc/feature_engineering/notebooks/GenerateAndWriteFeatures",
-                  "base_parameters": {                    
-                    "input_table_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled",
-                    "timestamp_column": "tpep_dropoff_datetime",
-                    "output_table_name": "feature_store_taxi_example.trip_dropoff_features_test",
-                    "features_transform_module": "dropoff_features",
-                    "primary_keys": "zip"
-                  }
-                },
-                "new_cluster": {
-                  "spark_version": "12.2.x-cpu-ml-scala2.12",
-                  "node_type_id": "${{ env.NODE_TYPE_ID }}",
-                  "num_workers": 0,
-                  "spark_conf": {
-                    "spark.databricks.cluster.profile": "singleNode",
-                    "spark.master": "local[*, 4]"
-                  },
-                  "custom_tags": {
-                    "ResourceClass": "SingleNode",
-                    "clusterSource": "mlops-stack/0.0"
-                  }
-                }
-              },
-              {
-                "task_key": "training",
-                "depends_on": [
-                  {
-                    "task_key": "dropoff-features"
-                  },
-                  {
-                    "task_key": "pickup-features"
-                  }
-                ],
-                "notebook_task": {
-                  "notebook_path": "mlops-poc/training/notebooks/TrainWithFeatureStore",
-                  "base_parameters": {
-                    "env": "staging",
-                    "training_data_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled",
-                    "experiment_name": "/mlops-poc-staging/test-mlops-poc-experiment",
-                    "model_name": "test-mlops-poc-model",
-                    "pickup_features_table": "feature_store_taxi_example.trip_pickup_features_test",
-                    "dropoff_features_table": "feature_store_taxi_example.trip_dropoff_features_test"
-                  }
-                },
-                "new_cluster": {
-                  "spark_version": "12.2.x-cpu-ml-scala2.12",
-                  "node_type_id": "${{ env.NODE_TYPE_ID }}",
-                  "num_workers": 0,
-                  "spark_conf": {
-                    "spark.databricks.cluster.profile": "singleNode",
-                    "spark.master": "local[*, 4]"
-                  },
-                  "custom_tags": {
-                    "ResourceClass": "SingleNode",
-                    "clusterSource": "mlops-stack/0.0"
-                  }
-                }
-              }
-            ],
-            "git_source": {
-              "git_url": "${{ github.server_url }}/${{ github.repository }}",
-              "git_provider": "gitHub",
-              "git_commit": "${{ github.event.pull_request.head.sha || github.sha }}"
-            },
-            "access_control_list": [
-              {
-                "group_name": "users",
-                "permission_level": "CAN_VIEW"
-              }
-            ]
-            }`
-            return output.replace(/\r?\n|\r/g, '')
-      - name: Upgrade Requests
-        run: pip install --upgrade requests
-      - name: Install databricks-cli
-        run: pip install databricks-cli
-      - name: Set databricks jobs
-        run: databricks jobs configure --version=2.1
-      - name: get test.json file
-        run: echo ${{steps.integration-test-content.outputs.result}} > test.json
-      # - name: Trigger GenerateAndWriteFeatures from PR branch
-      #   uses: databricks/run-notebook@v0
-      #   with:
-      #     local-notebook-path: mlops-poc/feature_engineering/notebooks/GenerateAndWriteFeatures
-      #     databricks-host: ${{ env.DATABRICKS_HOST }}
-      #     databricks-token: ${{ env.DATABRICKS_TOKEN }}
-      #     git-commit: ${{ github.event.pull_request.head.sha || github.sha }}
-      #     new-cluster-json: >
-      #       {
-      #         "spark_version": "12.2.x-cpu-ml-scala2.12",
-      #         "node_type_id": "${{ env.NODE_TYPE_ID }}",
-      #         "num_workers": 0,
-      #         "spark_conf": {
-      #           "spark.databricks.cluster.profile": "singleNode",
-      #           "spark.master": "local[*, 4]"
-      #         },
-      #         "custom_tags": {
-      #           "ResourceClass": "SingleNode",
-      #           "clusterSource": "mlops-stack/0.0"
-      #         }
-      #       }
-      #     # Grant all users view permission on the notebook results
-      #     access-control-list-json: >
-      #       [
-      #         {
-      #           "group_name": "users",
-      #           "permission_level": "CAN_VIEW"
-      #         }
-      #       ]
-      # - name: Trigger model training notebook from PR branch
-      #   uses: databricks/run-notebook@v0
-      #   with:
-      #     local-notebook-path: mlops-poc/feature_engineering/notebooks/GenerateAndWriteFeatures
-      #     databricks-host: ${{ env.DATABRICKS_HOST }}
-      #     databricks-token: ${{ env.DATABRICKS_TOKEN }}
-      #     git-commit: ${{ github.event.pull_request.head.sha || github.sha }}
-      #     new-cluster-json: >
-      #       {
-      #         "spark_version": "12.2.x-cpu-ml-scala2.12",
-      #         "node_type_id": "${{ env.NODE_TYPE_ID }}",
-      #         "num_workers": 0,
-      #         "spark_conf": {
-      #           "spark.databricks.cluster.profile": "singleNode",
-      #           "spark.master": "local[*, 4]"
-      #         },
-      #         "custom_tags": {
-      #           "ResourceClass": "SingleNode",
-      #           "clusterSource": "mlops-stack/0.0"
-      #         }
-      #       }
-      #     # Grant all users view permission on the notebook results
-      #     access-control-list-json: >
-      #       [
-      #         {
-      #           "group_name": "users",
-      #           "permission_level": "CAN_VIEW"
-      #         }
-      #       ]
-      # - name: Feature Store/Model Training Integration Test
-      #   id: features-training-integration-test
-      #   run: databricks runs submit --json-file test.json --wait > tmp-output.json
-      #   # We want to extract the run id as it's useful to show in the Github UI (as a comment).
-      # - name: extract run id
-      #   run: |
-      #     head -3  tmp-output.json  | jq '.run_id'  > run-id.json
-      #     databricks runs get --run-id "$(cat run-id.json)" | jq -r '.run_page_url' > run-page-url.json
-      #     echo "run-url=$(cat run-page-url.json)" >> "$GITHUB_OUTPUT"
-      # - name: Create Comment with Training Model Output
-      #   uses: actions/github-script@v6
-      #   id: comment
-      #   with:
-      #     github-token: ${{ secrets.GITHUB_TOKEN }}
-      #     script: |
-      #       const output = `
-      #       The training integration test run is available [here](${{ steps.features-training-integration-test.outputs.run-url }}).`
+#       # - name: read workspace id
+#       #   id: workspace
+#       #   run: echo "::set-output name=id::$(cat workspaces.json | jq -c '.workspaces[] | select(.name == "My Workspace").id')"
+#       # - name: Generate AAD Token
+#       #   run: ./.github/workflows/scripts/generate-aad-token.sh ${{ secrets.stagingAzureSpTenantId }} ${{ secrets.stagingAzureSpApplicationId }} ${{ secrets.stagingAzureSpClientSecret }}
+#       # This step populates a JSON Databricks job payload that will be submitted as an integration test run.
+#       # It currently builds a one-off multi-task job that contains feature engineering tasks to populate Feature
+#       # Store tables, and a training task that uses those tables.
+#       # You will need to modify the contents below to fit your pipelines (both # of tasks and input parameters for each
+#       # task).
+#       - name: Build JSON job payload for integration test
+#         uses: actions/github-script@v6
+#         id: integration-test-content
+#         with:
+#           # TODO update the tasks and notebook parameters below to match your integration test setup.
+#           script: |
+#             const output = `
+#                     {
+#             "run_name": "features-training-integration-test",
+#             "tasks": [
+#               {
+#                 "task_key": "pickup-features",
+#                 "notebook_task": {
+#                   "notebook_path": "mlops-poc/feature_engineering/notebooks/GenerateAndWriteFeatures",
+#                   "base_parameters": {
+#                     "input_table_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled",
+#                     "timestamp_column": "tpep_pickup_datetime",
+#                     "output_table_name": "feature_store_taxi_example.trip_pickup_features_test",
+#                     "features_transform_module": "pickup_features",
+#                     "primary_keys": "zip"
+#                   }
+#                 },
+#                 "new_cluster": {
+#                   "spark_version": "12.2.x-cpu-ml-scala2.12",
+#                   "node_type_id": "${{ env.NODE_TYPE_ID }}",
+#                   "num_workers": 0,
+#                   "spark_conf": {
+#                     "spark.databricks.cluster.profile": "singleNode",
+#                     "spark.master": "local[*, 4]"
+#                   },
+#                   "custom_tags": {
+#                     "ResourceClass": "SingleNode",
+#                     "clusterSource": "mlops-stack/0.0"
+#                   }
+#                 }
+#               },
+#               {
+#                 "task_key": "dropoff-features",
+#                 "notebook_task": {
+#                   "notebook_path": "mlops-poc/feature_engineering/notebooks/GenerateAndWriteFeatures",
+#                   "base_parameters": {
+#                     "input_table_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled",
+#                     "timestamp_column": "tpep_dropoff_datetime",
+#                     "output_table_name": "feature_store_taxi_example.trip_dropoff_features_test",
+#                     "features_transform_module": "dropoff_features",
+#                     "primary_keys": "zip"
+#                   }
+#                 },
+#                 "new_cluster": {
+#                   "spark_version": "12.2.x-cpu-ml-scala2.12",
+#                   "node_type_id": "${{ env.NODE_TYPE_ID }}",
+#                   "num_workers": 0,
+#                   "spark_conf": {
+#                     "spark.databricks.cluster.profile": "singleNode",
+#                     "spark.master": "local[*, 4]"
+#                   },
+#                   "custom_tags": {
+#                     "ResourceClass": "SingleNode",
+#                     "clusterSource": "mlops-stack/0.0"
+#                   }
+#                 }
+#               },
+#               {
+#                 "task_key": "training",
+#                 "depends_on": [
+#                   {
+#                     "task_key": "dropoff-features"
+#                   },
+#                   {
+#                     "task_key": "pickup-features"
+#                   }
+#                 ],
+#                 "notebook_task": {
+#                   "notebook_path": "mlops-poc/training/notebooks/TrainWithFeatureStore",
+#                   "base_parameters": {
+#                     "env": "staging",
+#                     "training_data_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled",
+#                     "experiment_name": "/mlops-poc-staging/test-mlops-poc-experiment",
+#                     "model_name": "test-mlops-poc-model",
+#                     "pickup_features_table": "feature_store_taxi_example.trip_pickup_features_test",
+#                     "dropoff_features_table": "feature_store_taxi_example.trip_dropoff_features_test"
+#                   }
+#                 },
+#                 "new_cluster": {
+#                   "spark_version": "12.2.x-cpu-ml-scala2.12",
+#                   "node_type_id": "${{ env.NODE_TYPE_ID }}",
+#                   "num_workers": 0,
+#                   "spark_conf": {
+#                     "spark.databricks.cluster.profile": "singleNode",
+#                     "spark.master": "local[*, 4]"
+#                   },
+#                   "custom_tags": {
+#                     "ResourceClass": "SingleNode",
+#                     "clusterSource": "mlops-stack/0.0"
+#                   }
+#                 }
+#               }
+#             ],
+#             "git_source": {
+#               "git_url": "${{ github.server_url }}/${{ github.repository }}",
+#               "git_provider": "gitHub",
+#               "git_commit": "${{ github.event.pull_request.head.sha || github.sha }}"
+#             },
+#             "access_control_list": [
+#               {
+#                 "group_name": "users",
+#                 "permission_level": "CAN_VIEW"
+#               }
+#             ]
+#             }`
+#             return output.replace(/\r?\n|\r/g, '')
+#       - name: Upgrade Requests
+#         run: pip install --upgrade requests
+#       - name: Install databricks-cli
+#         run: pip install databricks-cli
+#       - name: Set databricks jobs
+#         run: databricks jobs configure --version=2.1
+#       - name: get test.json file
+#         run: echo ${{steps.integration-test-content.outputs.result}} > test.json
+#       # - name: Trigger GenerateAndWriteFeatures from PR branch
+#       #   uses: databricks/run-notebook@v0
+#       #   with:
+#       #     local-notebook-path: mlops-poc/feature_engineering/notebooks/GenerateAndWriteFeatures
+#       #     databricks-host: ${{ env.DATABRICKS_HOST }}
+#       #     databricks-token: ${{ env.DATABRICKS_TOKEN }}
+#       #     git-commit: ${{ github.event.pull_request.head.sha || github.sha }}
+#       #     new-cluster-json: >
+#       #       {
+#       #         "spark_version": "12.2.x-cpu-ml-scala2.12",
+#       #         "node_type_id": "${{ env.NODE_TYPE_ID }}",
+#       #         "num_workers": 0,
+#       #         "spark_conf": {
+#       #           "spark.databricks.cluster.profile": "singleNode",
+#       #           "spark.master": "local[*, 4]"
+#       #         },
+#       #         "custom_tags": {
+#       #           "ResourceClass": "SingleNode",
+#       #           "clusterSource": "mlops-stack/0.0"
+#       #         }
+#       #       }
+#       #     # Grant all users view permission on the notebook results
+#       #     access-control-list-json: >
+#       #       [
+#       #         {
+#       #           "group_name": "users",
+#       #           "permission_level": "CAN_VIEW"
+#       #         }
+#       #       ]
+#       # - name: Trigger model training notebook from PR branch
+#       #   uses: databricks/run-notebook@v0
+#       #   with:
+#       #     local-notebook-path: mlops-poc/feature_engineering/notebooks/GenerateAndWriteFeatures
+#       #     databricks-host: ${{ env.DATABRICKS_HOST }}
+#       #     databricks-token: ${{ env.DATABRICKS_TOKEN }}
+#       #     git-commit: ${{ github.event.pull_request.head.sha || github.sha }}
+#       #     new-cluster-json: >
+#       #       {
+#       #         "spark_version": "12.2.x-cpu-ml-scala2.12",
+#       #         "node_type_id": "${{ env.NODE_TYPE_ID }}",
+#       #         "num_workers": 0,
+#       #         "spark_conf": {
+#       #           "spark.databricks.cluster.profile": "singleNode",
+#       #           "spark.master": "local[*, 4]"
+#       #         },
+#       #         "custom_tags": {
+#       #           "ResourceClass": "SingleNode",
+#       #           "clusterSource": "mlops-stack/0.0"
+#       #         }
+#       #       }
+#       #     # Grant all users view permission on the notebook results
+#       #     access-control-list-json: >
+#       #       [
+#       #         {
+#       #           "group_name": "users",
+#       #           "permission_level": "CAN_VIEW"
+#       #         }
+#       #       ]
+#       # - name: Feature Store/Model Training Integration Test
+#       #   id: features-training-integration-test
+#       #   run: databricks runs submit --json-file test.json --wait > tmp-output.json
+#       #   # We want to extract the run id as it's useful to show in the Github UI (as a comment).
+#       # - name: extract run id
+#       #   run: |
+#       #     head -3  tmp-output.json  | jq '.run_id'  > run-id.json
+#       #     databricks runs get --run-id "$(cat run-id.json)" | jq -r '.run_page_url' > run-page-url.json
+#       #     echo "run-url=$(cat run-page-url.json)" >> "$GITHUB_OUTPUT"
+#       # - name: Create Comment with Training Model Output
+#       #   uses: actions/github-script@v6
+#       #   id: comment
+#       #   with:
+#       #     github-token: ${{ secrets.GITHUB_TOKEN }}
+#       #     script: |
+#       #       const output = `
+#       #       The training integration test run is available [here](${{ steps.features-training-integration-test.outputs.run-url }}).`
 
-      #       github.rest.issues.createComment({
-      #         issue_number: context.issue.number,
-      #         owner: context.repo.owner,
-      #         repo: context.repo.repo,
-      #         body: output
-      #       })
+#       #       github.rest.issues.createComment({
+#       #         issue_number: context.issue.number,
+#       #         owner: context.repo.owner,
+#       #         repo: context.repo.repo,
+#       #         body: output
+#       #       })

--- a/.github/workflows/run-tests-fs.yml
+++ b/.github/workflows/run-tests-fs.yml
@@ -1,266 +1,266 @@
-# name: Feature and Training Integration Tests for mlops-poc
-# on:
-#   workflow_dispatch:
-#   pull_request:
-#     paths-ignore:
-#       - "mlops-poc/terraform/**"
+name: Feature and Training Integration Tests for mlops-poc with Feature Store
+on:
+  workflow_dispatch:
+  pull_request:
+    paths-ignore:
+      - "mlops-poc/terraform/**"
 
-# env:
-#   DATABRICKS_HOST: https://adb-1778171230779412.12.azuredatabricks.net
-#   DATABRICKS_JOBS_API_VERSION: 2.1
-#   NODE_TYPE_ID: Standard_D3_v2
+env:
+  DATABRICKS_HOST: https://adb-1778171230779412.12.azuredatabricks.net
+  DATABRICKS_JOBS_API_VERSION: 2.1
+  NODE_TYPE_ID: Standard_D3_v2
 
-# concurrency: mlops-poc-feature-training-integration-test-staging
+concurrency: mlops-poc-feature-training-integration-test-staging
 
-# jobs:
-#   unit_tests:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v2
-#       - uses: actions/setup-python@v2
-#         with:
-#           python-version: 3.9
-#       # Feature store tests bring up a local Spark session, so Java is required.
-#       - uses: actions/setup-java@v2
-#         with:
-#           distribution: "temurin"
-#           java-version: "11"
-#       - name: Install dependencies
-#         run: |
-#           python -m pip install --upgrade pip
-#           pip install -r requirements.txt
-#           pip install -r test-requirements.txt
-#       - name: Run tests with pytest
-#         run: |
-#           cd mlops-poc
-#           pytest
-#           cd ..
+jobs:
+  unit_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      # Feature store tests bring up a local Spark session, so Java is required.
+      - uses: actions/setup-java@v2
+        with:
+          distribution: "temurin"
+          java-version: "11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r test-requirements.txt
+      - name: Run tests with pytest
+        run: |
+          cd mlops-poc
+          pytest
+          cd ..
 
-#   integration_test:
-#     needs: unit_tests
-#     runs-on: ubuntu-20.04
-#     steps:
-#       - name: Checkout repo
-#         uses: actions/checkout@v3
-#       - name: GET Databricks AAD Token
-#         run: |
-# DATABRICKS_TOKEN=$(curl --fail -X POST -H 'Content-Type: application/x-www-form-urlencoded' \
-#                                     "https://login.microsoftonline.com/${{ secrets.stagingAzureSpTenantId }}/oauth2/v2.0/token" \
-#                                     -d "client_id=${{ secrets.stagingAzureSpApplicationId }}" \
-#                                     -d 'grant_type=client_credentials' \
-#                                     -d 'scope=2ff814a6-3304-4ab8-85cb-cd0e6f879c1d%2F.default' \
-#                                     -d "client_secret=${{ secrets.stagingAzureSpClientSecret }}" |  jq -r  '.access_token')
-# echo "DATABRICKS_TOKEN=$DATABRICKS_TOKEN" >> "$GITHUB_ENV"
-#           echo "$DATABRICKS_TOKEN"
+  integration_test:
+    needs: unit_tests
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: GET Databricks AAD Token
+        run: |
+          DATABRICKS_TOKEN=$(curl --fail -X POST -H 'Content-Type: application/x-www-form-urlencoded' \
+                                              "https://login.microsoftonline.com/${{ secrets.stagingAzureSpTenantId }}/oauth2/v2.0/token" \
+                                              -d "client_id=${{ secrets.stagingAzureSpApplicationId }}" \
+                                              -d 'grant_type=client_credentials' \
+                                              -d 'scope=2ff814a6-3304-4ab8-85cb-cd0e6f879c1d%2F.default' \
+                                              -d "client_secret=${{ secrets.stagingAzureSpClientSecret }}" |  jq -r  '.access_token')
+          echo "DATABRICKS_TOKEN=$DATABRICKS_TOKEN" >> "$GITHUB_ENV"
+                    echo "$DATABRICKS_TOKEN"
 
-#       # - name: read workspace id
-#       #   id: workspace
-#       #   run: echo "::set-output name=id::$(cat workspaces.json | jq -c '.workspaces[] | select(.name == "My Workspace").id')"
-#       # - name: Generate AAD Token
-#       #   run: ./.github/workflows/scripts/generate-aad-token.sh ${{ secrets.stagingAzureSpTenantId }} ${{ secrets.stagingAzureSpApplicationId }} ${{ secrets.stagingAzureSpClientSecret }}
-#       # This step populates a JSON Databricks job payload that will be submitted as an integration test run.
-#       # It currently builds a one-off multi-task job that contains feature engineering tasks to populate Feature
-#       # Store tables, and a training task that uses those tables.
-#       # You will need to modify the contents below to fit your pipelines (both # of tasks and input parameters for each
-#       # task).
-#       - name: Build JSON job payload for integration test
-#         uses: actions/github-script@v6
-#         id: integration-test-content
-#         with:
-#           # TODO update the tasks and notebook parameters below to match your integration test setup.
-#           script: |
-#             const output = `
-#                     {
-#             "run_name": "features-training-integration-test",
-#             "tasks": [
-#               {
-#                 "task_key": "pickup-features",
-#                 "notebook_task": {
-#                   "notebook_path": "mlops-poc/feature_engineering/notebooks/GenerateAndWriteFeatures",
-#                   "base_parameters": {
-#                     "input_table_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled",
-#                     "timestamp_column": "tpep_pickup_datetime",
-#                     "output_table_name": "feature_store_taxi_example.trip_pickup_features_test",
-#                     "features_transform_module": "pickup_features",
-#                     "primary_keys": "zip"
-#                   }
-#                 },
-#                 "new_cluster": {
-#                   "spark_version": "12.2.x-cpu-ml-scala2.12",
-#                   "node_type_id": "${{ env.NODE_TYPE_ID }}",
-#                   "num_workers": 0,
-#                   "spark_conf": {
-#                     "spark.databricks.cluster.profile": "singleNode",
-#                     "spark.master": "local[*, 4]"
-#                   },
-#                   "custom_tags": {
-#                     "ResourceClass": "SingleNode",
-#                     "clusterSource": "mlops-stack/0.0"
-#                   }
-#                 }
-#               },
-#               {
-#                 "task_key": "dropoff-features",
-#                 "notebook_task": {
-#                   "notebook_path": "mlops-poc/feature_engineering/notebooks/GenerateAndWriteFeatures",
-#                   "base_parameters": {
-#                     "input_table_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled",
-#                     "timestamp_column": "tpep_dropoff_datetime",
-#                     "output_table_name": "feature_store_taxi_example.trip_dropoff_features_test",
-#                     "features_transform_module": "dropoff_features",
-#                     "primary_keys": "zip"
-#                   }
-#                 },
-#                 "new_cluster": {
-#                   "spark_version": "12.2.x-cpu-ml-scala2.12",
-#                   "node_type_id": "${{ env.NODE_TYPE_ID }}",
-#                   "num_workers": 0,
-#                   "spark_conf": {
-#                     "spark.databricks.cluster.profile": "singleNode",
-#                     "spark.master": "local[*, 4]"
-#                   },
-#                   "custom_tags": {
-#                     "ResourceClass": "SingleNode",
-#                     "clusterSource": "mlops-stack/0.0"
-#                   }
-#                 }
-#               },
-#               {
-#                 "task_key": "training",
-#                 "depends_on": [
-#                   {
-#                     "task_key": "dropoff-features"
-#                   },
-#                   {
-#                     "task_key": "pickup-features"
-#                   }
-#                 ],
-#                 "notebook_task": {
-#                   "notebook_path": "mlops-poc/training/notebooks/TrainWithFeatureStore",
-#                   "base_parameters": {
-#                     "env": "staging",
-#                     "training_data_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled",
-#                     "experiment_name": "/mlops-poc-staging/test-mlops-poc-experiment",
-#                     "model_name": "test-mlops-poc-model",
-#                     "pickup_features_table": "feature_store_taxi_example.trip_pickup_features_test",
-#                     "dropoff_features_table": "feature_store_taxi_example.trip_dropoff_features_test"
-#                   }
-#                 },
-#                 "new_cluster": {
-#                   "spark_version": "12.2.x-cpu-ml-scala2.12",
-#                   "node_type_id": "${{ env.NODE_TYPE_ID }}",
-#                   "num_workers": 0,
-#                   "spark_conf": {
-#                     "spark.databricks.cluster.profile": "singleNode",
-#                     "spark.master": "local[*, 4]"
-#                   },
-#                   "custom_tags": {
-#                     "ResourceClass": "SingleNode",
-#                     "clusterSource": "mlops-stack/0.0"
-#                   }
-#                 }
-#               }
-#             ],
-#             "git_source": {
-#               "git_url": "${{ github.server_url }}/${{ github.repository }}",
-#               "git_provider": "gitHub",
-#               "git_commit": "${{ github.event.pull_request.head.sha || github.sha }}"
-#             },
-#             "access_control_list": [
-#               {
-#                 "group_name": "users",
-#                 "permission_level": "CAN_VIEW"
-#               }
-#             ]
-#             }`
-#             return output.replace(/\r?\n|\r/g, '')
-#       - name: Upgrade Requests
-#         run: pip install --upgrade requests
-#       - name: Install databricks-cli
-#         run: pip install databricks-cli
-#       - name: Set databricks jobs
-#         run: databricks jobs configure --version=2.1
-#       - name: get test.json file
-#         run: echo ${{steps.integration-test-content.outputs.result}} > test.json
-#       # - name: Trigger GenerateAndWriteFeatures from PR branch
-#       #   uses: databricks/run-notebook@v0
-#       #   with:
-#       #     local-notebook-path: mlops-poc/feature_engineering/notebooks/GenerateAndWriteFeatures
-#       #     databricks-host: ${{ env.DATABRICKS_HOST }}
-#       #     databricks-token: ${{ env.DATABRICKS_TOKEN }}
-#       #     git-commit: ${{ github.event.pull_request.head.sha || github.sha }}
-#       #     new-cluster-json: >
-#       #       {
-#       #         "spark_version": "12.2.x-cpu-ml-scala2.12",
-#       #         "node_type_id": "${{ env.NODE_TYPE_ID }}",
-#       #         "num_workers": 0,
-#       #         "spark_conf": {
-#       #           "spark.databricks.cluster.profile": "singleNode",
-#       #           "spark.master": "local[*, 4]"
-#       #         },
-#       #         "custom_tags": {
-#       #           "ResourceClass": "SingleNode",
-#       #           "clusterSource": "mlops-stack/0.0"
-#       #         }
-#       #       }
-#       #     # Grant all users view permission on the notebook results
-#       #     access-control-list-json: >
-#       #       [
-#       #         {
-#       #           "group_name": "users",
-#       #           "permission_level": "CAN_VIEW"
-#       #         }
-#       #       ]
-#       # - name: Trigger model training notebook from PR branch
-#       #   uses: databricks/run-notebook@v0
-#       #   with:
-#       #     local-notebook-path: mlops-poc/feature_engineering/notebooks/GenerateAndWriteFeatures
-#       #     databricks-host: ${{ env.DATABRICKS_HOST }}
-#       #     databricks-token: ${{ env.DATABRICKS_TOKEN }}
-#       #     git-commit: ${{ github.event.pull_request.head.sha || github.sha }}
-#       #     new-cluster-json: >
-#       #       {
-#       #         "spark_version": "12.2.x-cpu-ml-scala2.12",
-#       #         "node_type_id": "${{ env.NODE_TYPE_ID }}",
-#       #         "num_workers": 0,
-#       #         "spark_conf": {
-#       #           "spark.databricks.cluster.profile": "singleNode",
-#       #           "spark.master": "local[*, 4]"
-#       #         },
-#       #         "custom_tags": {
-#       #           "ResourceClass": "SingleNode",
-#       #           "clusterSource": "mlops-stack/0.0"
-#       #         }
-#       #       }
-#       #     # Grant all users view permission on the notebook results
-#       #     access-control-list-json: >
-#       #       [
-#       #         {
-#       #           "group_name": "users",
-#       #           "permission_level": "CAN_VIEW"
-#       #         }
-#       #       ]
-#       # - name: Feature Store/Model Training Integration Test
-#       #   id: features-training-integration-test
-#       #   run: databricks runs submit --json-file test.json --wait > tmp-output.json
-#       #   # We want to extract the run id as it's useful to show in the Github UI (as a comment).
-#       # - name: extract run id
-#       #   run: |
-#       #     head -3  tmp-output.json  | jq '.run_id'  > run-id.json
-#       #     databricks runs get --run-id "$(cat run-id.json)" | jq -r '.run_page_url' > run-page-url.json
-#       #     echo "run-url=$(cat run-page-url.json)" >> "$GITHUB_OUTPUT"
-#       # - name: Create Comment with Training Model Output
-#       #   uses: actions/github-script@v6
-#       #   id: comment
-#       #   with:
-#       #     github-token: ${{ secrets.GITHUB_TOKEN }}
-#       #     script: |
-#       #       const output = `
-#       #       The training integration test run is available [here](${{ steps.features-training-integration-test.outputs.run-url }}).`
+      # - name: read workspace id
+      #   id: workspace
+      #   run: echo "::set-output name=id::$(cat workspaces.json | jq -c '.workspaces[] | select(.name == "My Workspace").id')"
+      # - name: Generate AAD Token
+      #   run: ./.github/workflows/scripts/generate-aad-token.sh ${{ secrets.stagingAzureSpTenantId }} ${{ secrets.stagingAzureSpApplicationId }} ${{ secrets.stagingAzureSpClientSecret }}
+      # This step populates a JSON Databricks job payload that will be submitted as an integration test run.
+      # It currently builds a one-off multi-task job that contains feature engineering tasks to populate Feature
+      # Store tables, and a training task that uses those tables.
+      # You will need to modify the contents below to fit your pipelines (both # of tasks and input parameters for each
+      # task).
+      - name: Build JSON job payload for integration test
+        uses: actions/github-script@v6
+        id: integration-test-content
+        with:
+          # TODO update the tasks and notebook parameters below to match your integration test setup.
+          script: |
+            const output = `
+                    {
+            "run_name": "features-training-integration-test",
+            "tasks": [
+              {
+                "task_key": "pickup-features",
+                "notebook_task": {
+                  "notebook_path": "mlops-poc/feature_engineering/notebooks/GenerateAndWriteFeatures",
+                  "base_parameters": {
+                    "input_table_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled",
+                    "timestamp_column": "tpep_pickup_datetime",
+                    "output_table_name": "feature_store_taxi_example.trip_pickup_features_test",
+                    "features_transform_module": "pickup_features",
+                    "primary_keys": "zip"
+                  }
+                },
+                "new_cluster": {
+                  "spark_version": "12.2.x-cpu-ml-scala2.12",
+                  "node_type_id": "${{ env.NODE_TYPE_ID }}",
+                  "num_workers": 0,
+                  "spark_conf": {
+                    "spark.databricks.cluster.profile": "singleNode",
+                    "spark.master": "local[*, 4]"
+                  },
+                  "custom_tags": {
+                    "ResourceClass": "SingleNode",
+                    "clusterSource": "mlops-stack/0.0"
+                  }
+                }
+              },
+              {
+                "task_key": "dropoff-features",
+                "notebook_task": {
+                  "notebook_path": "mlops-poc/feature_engineering/notebooks/GenerateAndWriteFeatures",
+                  "base_parameters": {
+                    "input_table_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled",
+                    "timestamp_column": "tpep_dropoff_datetime",
+                    "output_table_name": "feature_store_taxi_example.trip_dropoff_features_test",
+                    "features_transform_module": "dropoff_features",
+                    "primary_keys": "zip"
+                  }
+                },
+                "new_cluster": {
+                  "spark_version": "12.2.x-cpu-ml-scala2.12",
+                  "node_type_id": "${{ env.NODE_TYPE_ID }}",
+                  "num_workers": 0,
+                  "spark_conf": {
+                    "spark.databricks.cluster.profile": "singleNode",
+                    "spark.master": "local[*, 4]"
+                  },
+                  "custom_tags": {
+                    "ResourceClass": "SingleNode",
+                    "clusterSource": "mlops-stack/0.0"
+                  }
+                }
+              },
+              {
+                "task_key": "training",
+                "depends_on": [
+                  {
+                    "task_key": "dropoff-features"
+                  },
+                  {
+                    "task_key": "pickup-features"
+                  }
+                ],
+                "notebook_task": {
+                  "notebook_path": "mlops-poc/training/notebooks/TrainWithFeatureStore",
+                  "base_parameters": {
+                    "env": "staging",
+                    "training_data_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled",
+                    "experiment_name": "/mlops-poc-staging/test-mlops-poc-experiment",
+                    "model_name": "test-mlops-poc-model",
+                    "pickup_features_table": "feature_store_taxi_example.trip_pickup_features_test",
+                    "dropoff_features_table": "feature_store_taxi_example.trip_dropoff_features_test"
+                  }
+                },
+                "new_cluster": {
+                  "spark_version": "12.2.x-cpu-ml-scala2.12",
+                  "node_type_id": "${{ env.NODE_TYPE_ID }}",
+                  "num_workers": 0,
+                  "spark_conf": {
+                    "spark.databricks.cluster.profile": "singleNode",
+                    "spark.master": "local[*, 4]"
+                  },
+                  "custom_tags": {
+                    "ResourceClass": "SingleNode",
+                    "clusterSource": "mlops-stack/0.0"
+                  }
+                }
+              }
+            ],
+            "git_source": {
+              "git_url": "${{ github.server_url }}/${{ github.repository }}",
+              "git_provider": "gitHub",
+              "git_commit": "${{ github.event.pull_request.head.sha || github.sha }}"
+            },
+            "access_control_list": [
+              {
+                "group_name": "users",
+                "permission_level": "CAN_VIEW"
+              }
+            ]
+            }`
+            return output.replace(/\r?\n|\r/g, '')
+      - name: Upgrade Requests
+        run: pip install --upgrade requests
+      - name: Install databricks-cli
+        run: pip install databricks-cli
+      - name: Set databricks jobs
+        run: databricks jobs configure --version=2.1
+      - name: get test.json file
+        run: echo ${{steps.integration-test-content.outputs.result}} > test.json
+      # - name: Trigger GenerateAndWriteFeatures from PR branch
+      #   uses: databricks/run-notebook@v0
+      #   with:
+      #     local-notebook-path: mlops-poc/feature_engineering/notebooks/GenerateAndWriteFeatures
+      #     databricks-host: ${{ env.DATABRICKS_HOST }}
+      #     databricks-token: ${{ env.DATABRICKS_TOKEN }}
+      #     git-commit: ${{ github.event.pull_request.head.sha || github.sha }}
+      #     new-cluster-json: >
+      #       {
+      #         "spark_version": "12.2.x-cpu-ml-scala2.12",
+      #         "node_type_id": "${{ env.NODE_TYPE_ID }}",
+      #         "num_workers": 0,
+      #         "spark_conf": {
+      #           "spark.databricks.cluster.profile": "singleNode",
+      #           "spark.master": "local[*, 4]"
+      #         },
+      #         "custom_tags": {
+      #           "ResourceClass": "SingleNode",
+      #           "clusterSource": "mlops-stack/0.0"
+      #         }
+      #       }
+      #     # Grant all users view permission on the notebook results
+      #     access-control-list-json: >
+      #       [
+      #         {
+      #           "group_name": "users",
+      #           "permission_level": "CAN_VIEW"
+      #         }
+      #       ]
+      # - name: Trigger model training notebook from PR branch
+      #   uses: databricks/run-notebook@v0
+      #   with:
+      #     local-notebook-path: mlops-poc/feature_engineering/notebooks/GenerateAndWriteFeatures
+      #     databricks-host: ${{ env.DATABRICKS_HOST }}
+      #     databricks-token: ${{ env.DATABRICKS_TOKEN }}
+      #     git-commit: ${{ github.event.pull_request.head.sha || github.sha }}
+      #     new-cluster-json: >
+      #       {
+      #         "spark_version": "12.2.x-cpu-ml-scala2.12",
+      #         "node_type_id": "${{ env.NODE_TYPE_ID }}",
+      #         "num_workers": 0,
+      #         "spark_conf": {
+      #           "spark.databricks.cluster.profile": "singleNode",
+      #           "spark.master": "local[*, 4]"
+      #         },
+      #         "custom_tags": {
+      #           "ResourceClass": "SingleNode",
+      #           "clusterSource": "mlops-stack/0.0"
+      #         }
+      #       }
+      #     # Grant all users view permission on the notebook results
+      #     access-control-list-json: >
+      #       [
+      #         {
+      #           "group_name": "users",
+      #           "permission_level": "CAN_VIEW"
+      #         }
+      #       ]
+      # - name: Feature Store/Model Training Integration Test
+      #   id: features-training-integration-test
+      #   run: databricks runs submit --json-file test.json --wait > tmp-output.json
+      #   # We want to extract the run id as it's useful to show in the Github UI (as a comment).
+      # - name: extract run id
+      #   run: |
+      #     head -3  tmp-output.json  | jq '.run_id'  > run-id.json
+      #     databricks runs get --run-id "$(cat run-id.json)" | jq -r '.run_page_url' > run-page-url.json
+      #     echo "run-url=$(cat run-page-url.json)" >> "$GITHUB_OUTPUT"
+      # - name: Create Comment with Training Model Output
+      #   uses: actions/github-script@v6
+      #   id: comment
+      #   with:
+      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+      #     script: |
+      #       const output = `
+      #       The training integration test run is available [here](${{ steps.features-training-integration-test.outputs.run-url }}).`
 
-#       #       github.rest.issues.createComment({
-#       #         issue_number: context.issue.number,
-#       #         owner: context.repo.owner,
-#       #         repo: context.repo.repo,
-#       #         body: output
-#       #       })
+      #       github.rest.issues.createComment({
+      #         issue_number: context.issue.number,
+      #         owner: context.repo.owner,
+      #         repo: context.repo.repo,
+      #         body: output
+      #       })

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,7 +30,7 @@ jobs:
 
   integration_test:
     needs: unit_tests
-    runs-on: ubuntu0.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,80 @@
+name: ML Code Tests for mlops-poc
+on:
+  workflow_dispatch:
+  pull_request:
+    paths-ignore:
+      - "mlops-poc/terraform/**"
+
+env:
+  DATABRICKS_HOST: https://adb-1778171230779412.12.azuredatabricks.net
+  NODE_TYPE_ID: Standard_D3_v2
+
+jobs:
+  unit_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r test-requirements.txt
+      - name: Run tests with pytest
+        run: |
+          cd mlops-poc
+          pytest
+          cd ..
+
+  integration_test:
+    needs: unit_tests
+    runs-on: ubuntu0.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Generate AAD Token
+        run: |
+          DATABRICKS_TOKEN=$(curl --fail -X POST -H 'Content-Type: application/x-www-form-urlencoded' \
+          "https://login.microsoftonline.com/${{ secrets.stagingAzureSpTenantId }}/oauth2/v2.0/token" \
+          -d "client_id=${{ secrets.stagingAzureSpApplicationId }}" \
+          -d 'grant_type=client_credentials' \
+          -d 'scope=2ff814a6-3304-4ab8-85cb-cd0e6f879c1d%2F.default' \
+          -d "client_secret=${{ secrets.stagingAzureSpClientSecret }}" |  jq -r  '.access_token')
+          echo "DATABRICKS_TOKEN=$DATABRICKS_TOKEN" >> "$GITHUB_ENV"
+      - name: Train model
+        uses: databricks/run-notebook@v0
+        id: train
+        with:
+          local-notebook-path: mlops-poc/training/notebooks/Train.py
+          git-commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          git-provider: gitHub
+          new-cluster-json: >
+            {
+              "spark_version": "12.2.x-cpu-ml-scala2.12",
+              "node_type_id": "${{ env.NODE_TYPE_ID }}",
+              "num_workers": 0,
+              "spark_conf": {
+                "spark.databricks.cluster.profile": "singleNode",
+                "spark.master": "local[*, 4]"
+              },
+              "custom_tags": {
+                "ResourceClass": "SingleNode",
+                "clusterSource": "mlops-stack/0.0"
+              }
+            }
+          access-control-list-json: >
+            [
+              {
+                "group_name": "users",
+                "permission_level": "CAN_VIEW"
+              }
+            ]
+          run-name: mlops-poc Integration Test
+          notebook-params-json: >
+            {
+              "env": "test"
+            }
+
+          pr-comment-github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/mlops-poc/terraform/prod/training-job.tf
+++ b/mlops-poc/terraform/prod/training-job.tf
@@ -14,13 +14,14 @@ resource "databricks_job" "model_training_job" {
     task_key = "Train"
 
     notebook_task {
-      notebook_path = "mlops-poc/training/notebooks/TrainWithFeatureStore"
+      # notebook_path = "mlops-poc/training/notebooks/TrainWithFeatureStore"
+      notebook_path = "mlops-poc/training/notebooks/Train"
       base_parameters = {
         env = local.env
         # TODO: Update training_data_path
-        training_data_path = "/databricks-datasets/nyctaxi-with-zipcodes/subsampled"
-        experiment_name    = databricks_mlflow_experiment.experiment.name
-        model_name         = "${local.env_prefix}mlops-poc-model"
+        # training_data_path = "/databricks-datasets/nyctaxi-with-zipcodes/subsampled"
+        experiment_name = databricks_mlflow_experiment.experiment.name
+        model_name      = "${local.env_prefix}mlops-poc-model"
       }
     }
 
@@ -45,6 +46,7 @@ resource "databricks_job" "model_training_job" {
     notebook_task {
       notebook_path = "mlops-poc/validation/notebooks/ModelValidation"
       base_parameters = {
+        env             = local.env
         experiment_name = databricks_mlflow_experiment.experiment.name
         # The `run_mode` defines whether model validation is enabled or not.
         # It can be one of the three values:
@@ -62,14 +64,6 @@ resource "databricks_job" "model_training_job" {
         # Please refer to data parameter in mlflow.evaluate documentation https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate
         # TODO: update validation_input
         validation_input = "SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`"
-        # A string describing the model type. The model type can be either "regressor" and "classifier".
-        # Please refer to model_type parameter in mlflow.evaluate documentation https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate
-        # TODO: update model_type
-        model_type = "regressor"
-        # The string name of a column from data that contains evaluation labels.
-        # Please refer to targets parameter in mlflow.evaluate documentation https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate
-        # TODO: targets
-        targets = "mean_squared_error"
         # Specifies the name of the function in mlops-poc/validation/validation.py that returns custom metrics.
         # TODO(optional): custom_metrics_loader_function
         custom_metrics_loader_function = "custom_metrics"

--- a/mlops-poc/terraform/staging/training-job.tf
+++ b/mlops-poc/terraform/staging/training-job.tf
@@ -14,7 +14,8 @@ resource "databricks_job" "model_training_job" {
     task_key = "Train"
 
     notebook_task {
-      notebook_path = "mlops-poc/training/notebooks/TrainWithFeatureStore"
+      # notebook_path = "mlops-poc/training/notebooks/TrainWithFeatureStore"
+      notebook_path = "mlops-poc/training/notebooks/Train"
       base_parameters = {
         env = local.env
         # TODO: Update training_data_path
@@ -41,6 +42,7 @@ resource "databricks_job" "model_training_job" {
     notebook_task {
       notebook_path = "mlops-poc/validation/notebooks/ModelValidation"
       base_parameters = {
+        env             = local.env
         experiment_name = databricks_mlflow_experiment.experiment.name
         # The `run_mode` defines whether model validation is enabled or not.
         # It can be one of the three values:
@@ -58,14 +60,6 @@ resource "databricks_job" "model_training_job" {
         # Please refer to data parameter in mlflow.evaluate documentation https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate
         # TODO: update validation_input
         validation_input = "SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`"
-        # A string describing the model type. The model type can be either "regressor" and "classifier".
-        # Please refer to model_type parameter in mlflow.evaluate documentation https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate
-        # TODO: update model_type
-        model_type = "regressor"
-        # The string name of a column from data that contains evaluation labels.
-        # Please refer to targets parameter in mlflow.evaluate documentation https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate
-        # TODO: targets
-        targets = "mean_squared_error"
         # Specifies the name of the function in mlops-poc/validation/validation.py that returns custom metrics.
         # TODO(optional): custom_metrics_loader_function
         custom_metrics_loader_function = "custom_metrics"
@@ -76,6 +70,42 @@ resource "databricks_job" "model_training_job" {
         # TODO(optional): evaluator_config_loader_function
         evaluator_config_loader_function = "evaluator_config"
       }
+      # base_parameters = {
+      #   experiment_name = databricks_mlflow_experiment.experiment.name
+      #   # The `run_mode` defines whether model validation is enabled or not.
+      #   # It can be one of the three values:
+      #   # `disabled` : Do not run the model validation notebook.
+      #   # `dry_run`  : Run the model validation notebook. Ignore failed model validation rules and proceed to move
+      #   #               model to Production stage.
+      #   # `enabled`  : Run the model validation notebook. Move model to Production stage only if all model validation
+      #   #               rules are passing.
+      #   # TODO: update run_mode
+      #   run_mode = "enabled"
+      #   # Whether to load the current registered "Production" stage model as baseline.
+      #   # Baseline model is a requirement for relative change and absolute change validation thresholds.
+      #   # TODO: update enable_baseline_comparison
+      #   enable_baseline_comparison = "true"
+      #   # Please refer to data parameter in mlflow.evaluate documentation https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate
+      #   # TODO: update validation_input
+      #   validation_input = "SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`"
+      #   # A string describing the model type. The model type can be either "regressor" and "classifier".
+      #   # Please refer to model_type parameter in mlflow.evaluate documentation https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate
+      #   # TODO: update model_type
+      #   model_type = "regressor"
+      #   # The string name of a column from data that contains evaluation labels.
+      #   # Please refer to targets parameter in mlflow.evaluate documentation https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate
+      #   # TODO: targets
+      #   targets = "mean_squared_error"
+      #   # Specifies the name of the function in mlops-poc/validation/validation.py that returns custom metrics.
+      #   # TODO(optional): custom_metrics_loader_function
+      #   custom_metrics_loader_function = "custom_metrics"
+      #   # Specifies the name of the function in mlops-poc/validation/validation.py that returns model validation thresholds.
+      #   # TODO(optional): validation_thresholds_loader_function
+      #   validation_thresholds_loader_function = "validation_thresholds"
+      #   # Specifies the name of the function in mlops-poc/validation/validation.py that returns evaluator_config.
+      #   # TODO(optional): evaluator_config_loader_function
+      #   evaluator_config_loader_function = "evaluator_config"
+      # }
     }
 
     new_cluster {

--- a/mlops-poc/training/notebooks/Train.py
+++ b/mlops-poc/training/notebooks/Train.py
@@ -1,0 +1,113 @@
+# Databricks notebook source
+##################################################################################
+# Model Training Notebook
+##
+# This notebook runs the MLflow Regression Recipe to train and registers an MLflow model in the model registry.
+#
+# It's run as part of CI (to integration-test model training logic) and by an automated model training job
+# defined under ``mlops-poc-2/terraform``
+#
+# NOTE: In general, we recommend that you do not modify this notebook directly, and instead update data-loading
+# and model training logic in Python modules under the `steps` directory.
+# Modifying this notebook can break model training CI/CD.
+#
+# However, if you do need to make changes (e.g. to remove the use of MLflow Recipes APIs),
+# be sure to preserve the following interface expected by CI and the production model training job:
+#
+# Parameters:
+#
+# * env (optional): Name of the environment the notebook is run in (test, staging, or prod).
+#                   You can add environment-specific logic to this notebook based on the value of this parameter,
+#                   e.g. read training data from different tables or data sources across environments.
+#                   The `databricks-dev` profile will be used if users manually run the notebook.
+#                   The `databricks-test` profile will be used during CI test runs.
+#                   This separates the potentially many runs/models logged during integration tests from
+#                   runs/models produced by staging/production model training jobs. You can use the value of this
+#                   parameter to further customize the behavior of this notebook based on whether it's running as
+#                   a test or for recurring model training in staging/production.
+#
+#
+# Return values:
+# * model_uri: The notebook must return the URI of the registered model as notebook output specified through
+#              dbutils.notebook.exit() AND as a task value with key "model_uri" specified through
+#              dbutils.jobs.taskValues(...), for use by downstream notebooks.
+#
+# For details on MLflow Recipes and the individual split, transform, train etc steps below, including usage examples,
+# see the Regression Recipe overview documentation: https://mlflow.org/docs/latest/recipes.html
+# and Regression Recipes API documentation: https://mlflow.org/docs/latest/python_api/mlflow.recipes.html
+##################################################################################
+
+# COMMAND ----------
+# MAGIC %load_ext autoreload
+# MAGIC %autoreload 2
+
+# COMMAND ----------
+
+# MAGIC %pip install -r ../../../requirements.txt
+
+# COMMAND ----------
+
+from mlflow.recipes import Recipe
+
+try:
+    # Profile from databricks workflow input will be used.
+    env = dbutils.widgets.get("env")
+    profile = f"databricks-{env}"
+except:
+    # When the users manually run the notebook, we use the "databricks-dev" profile instead of staging, prod or test.
+    profile = "databricks-dev"
+
+# COMMAND ----------
+
+
+r = Recipe(profile=profile)
+
+# COMMAND ----------
+
+r.clean()
+
+# COMMAND ----------
+
+r.inspect()
+
+# COMMAND ----------
+
+r.run("ingest")
+
+# COMMAND ----------
+
+r.run("split")
+
+# COMMAND ----------
+
+r.run("transform")
+
+# COMMAND ----------
+
+r.run("train")
+
+# COMMAND ----------
+
+r.run("evaluate")
+
+# COMMAND ----------
+
+r.run("register")
+
+# COMMAND ----------
+
+r.inspect("train")
+
+# COMMAND ----------
+
+test_data = r.get_artifact("test_data")
+test_data.describe()
+
+# COMMAND ----------
+
+model_version = r.get_artifact("registered_model_version")
+model_uri = f"models:/{model_version.name}/{model_version.version}"
+dbutils.jobs.taskValues.set("model_uri", model_uri)
+dbutils.jobs.taskValues.set("model_name", model_version.name)
+dbutils.jobs.taskValues.set("model_version", model_version.version)
+dbutils.notebook.exit(model_uri)

--- a/mlops-poc/training/profiles/databricks-dev.yaml
+++ b/mlops-poc/training/profiles/databricks-dev.yaml
@@ -1,0 +1,36 @@
+# This profile contains config overrides for model development on Databricks
+experiment:
+  name: "/dev-mlops-poc-2-experiment"
+
+# Set the registry server URI. This property is especially useful if you have a registry
+# server that’s different from the tracking server.
+model_registry:
+  # Specify the MLflow registered model name under which to register model versions
+  model_name: "dev-mlops-poc-2-model"
+
+# Override the default train / validation / test dataset split ratios
+SPLIT_RATIOS: [0.75, 0.125, 0.125]
+
+INGEST_CONFIG:
+  # For different options please read: https://github.com/mlflow/recipes-regression-template#ingest-step
+  # TODO: Specify the format of the dataset
+  using: spark_sql
+  # TODO: update this field to point to the path to your model training dataset on the Databricks workspace
+  # you use for development
+  sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+  loader_method: load_file_as_dataframe
+
+INGEST_SCORING_CONFIG:
+  # For different options please read: https://github.com/mlflow/recipes-regression-template#batch-scoring
+  # TODO: Specify the format of the dataset
+  using: spark_sql
+  # TODO: Specify the name/path of the input table for batch inference in your dev workspace here
+  sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+  loader_method: load_file_as_dataframe
+
+PREDICT_OUTPUT_CONFIG:
+  # For different options please read: https://github.com/mlflow/recipes-regression-template#predict-step
+  # Specify the output format of the batch scoring predict step
+  using: table
+  # TODO: Specify the name of the output table for batch inference in your dev workspace here
+  location: "mlops-poc_batch_scoring"

--- a/mlops-poc/training/profiles/databricks-prod.yaml
+++ b/mlops-poc/training/profiles/databricks-prod.yaml
@@ -1,0 +1,36 @@
+experiment:
+  name: {{ ('../../terraform/output/prod.json' | from_json)["mlops-poc_experiment_name"]["value"]}}
+
+# Set the registry server URI. This property is especially useful if you have a registry
+# server that’s different from the tracking server.
+model_registry:
+  # The MLflow registered model name under which to register model versions
+  # In prod, we log to the model provisioned through ML configs under mlops-poc/terraform
+  # See mlops-poc/terraform/README.md for details
+  model_name: {{ ('../../terraform/output/prod.json' | from_json)["mlops-poc_model_name"]["value"]}}
+
+# Override the default train / validation / test dataset split ratios
+SPLIT_RATIOS: [0.75, 0.125, 0.125]
+
+INGEST_CONFIG:
+  # For different options please read: https://github.com/mlflow/recipes-regression-template#ingest-step
+  # TODO: Specify the format of the dataset
+  using: spark_sql
+  # TODO: update this field to point to the path to your model training dataset on your production Databricks workspace
+  sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+  loader_method: load_file_as_dataframe
+
+INGEST_SCORING_CONFIG:
+  # For different options please read: https://github.com/mlflow/recipes-regression-template#batch-scoring
+  # TODO: Specify the format of the dataset
+  using: spark_sql
+  # TODO: Specify the name/path of the input table for batch inference in your prod workspace here
+  sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+  loader_method: load_file_as_dataframe
+
+PREDICT_OUTPUT_CONFIG:
+  # For different options please read: https://github.com/mlflow/recipes-regression-template#predict-step
+  # Specify the output format of the batch scoring predict step
+  using: table
+  # TODO: Specify the name of the output table for batch inference in your prod workspace here
+  location: "mlops-poc_batch_scoring"

--- a/mlops-poc/training/profiles/databricks-staging.yaml
+++ b/mlops-poc/training/profiles/databricks-staging.yaml
@@ -1,0 +1,38 @@
+experiment:
+  name: {{ ('../../terraform/output/staging.json' | from_json)["mlops-poc_experiment_name"]["value"]}}
+
+# Set the registry server URI. This property is especially useful if you have a registry
+# server that’s different from the tracking server.
+model_registry:
+  # The MLflow registered model name under which to register model versions
+  # In prod, we log to the model provisioned through ML configs under mlops-poc/terraform
+  # See mlops-poc/terraform/README.md for details
+  model_name: {{ ('../../terraform/output/staging.json' | from_json)["mlops-poc_model_name"]["value"]}}
+
+# Override the default train / validation / test dataset split ratios
+SPLIT_RATIOS: [0.75, 0.125, 0.125]
+
+INGEST_CONFIG:
+  # For different options please read: https://github.com/mlflow/recipes-regression-template#ingest-step
+  # TODO: Specify the format of the dataset
+  using: spark_sql
+  # TODO: update this field to point to the path to your model training dataset on your staging Databricks workspace,
+  # to be used in the staging instance of your ML jobs. For example, you may want to create a downsampled version of your
+  # full production dataset and specify its path here.
+  sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+  loader_method: load_file_as_dataframe
+
+INGEST_SCORING_CONFIG:
+  # For different options please read: https://github.com/mlflow/recipes-regression-template#batch-scoring
+  # TODO: Specify the format of the dataset
+  using: spark_sql
+  # TODO: Specify the name/path of the input table for batch inference in your staging workspace here
+  sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+  loader_method: load_file_as_dataframe
+
+PREDICT_OUTPUT_CONFIG:
+  # For different options please read: https://github.com/mlflow/recipes-regression-template#predict-step
+  # Specify the output format of the batch scoring predict step
+  using: table
+  # TODO: Specify the name of the output table for batch inference in your prod workspace here
+  location: "mlops-poc_batch_scoring"

--- a/mlops-poc/training/profiles/databricks-test.yaml
+++ b/mlops-poc/training/profiles/databricks-test.yaml
@@ -1,0 +1,37 @@
+experiment:
+  name: "/mlops-poc-staging/test-mlops-poc-experiment"
+
+# Set the registry server URI. This property is especially useful if you have a registry
+# server that’s different from the tracking server.
+model_registry:
+  # Specifies the name of the Registered Model to use when registering a trained model to
+  # the MLflow Model Registry
+  model_name: "test-mlops-poc-model"
+
+# Override the default train / validation / test dataset split ratios
+SPLIT_RATIOS: [0.75, 0.125, 0.125]
+
+INGEST_CONFIG:
+  # For different options please read: https://github.com/mlflow/recipes-regression-template#ingest-step
+  # TODO: Specify the format of the dataset
+  using: spark_sql
+  # TODO: update this field to point to the path to your model training dataset on your staging Databricks workspace,
+  # to be used in tests. For example, you may want to create a down-sampled version of your full production dataset
+  # and specify its path here.
+  sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+  loader_method: load_file_as_dataframe
+
+INGEST_SCORING_CONFIG:
+  # For different options please read: https://github.com/mlflow/recipes-regression-template#batch-scoring
+  # TODO: Specify the format of the dataset
+  using: spark_sql
+  # TODO: Specify the name/path of the input table for batch inference tests here
+  sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+  loader_method: load_file_as_dataframe
+
+PREDICT_OUTPUT_CONFIG:
+  # For different options please read: https://github.com/mlflow/recipes-regression-template#predict-step
+  # Specify the output format of the batch scoring predict step
+  using: table
+  # TODO: Specify the name of the output table for batch inference in tests here
+  location: "mlops-poc_batch_scoring_test"

--- a/mlops-poc/training/profiles/local.yaml
+++ b/mlops-poc/training/profiles/local.yaml
@@ -1,0 +1,38 @@
+experiment:
+  name: "/Shared/mlops-poc"
+  tracking_uri: "sqlite:///mlruns.db"
+  artifact_location: "./mlruns"
+
+model_registry:
+  # Specifies the name of the Registered Model to use when registering a trained model to
+  # the MLflow Model Registry
+  model_name: {{MODEL_NAME|default('mlops-poc_model')}}
+
+# Override the default train / validation / test dataset split ratios
+SPLIT_RATIOS: [0.80, 0.10, 0.10]
+
+INGEST_CONFIG:
+  # For different options please read: https://github.com/mlflow/recipes-regression-template#ingest-step
+  # TODO: Specify the format of the dataset
+  using: parquet
+  # TODO: update this field to point to a local filesystem path containing e.g. a sample of your model training
+  # dataset for local development.
+  location: "../data/sample.parquet"
+  loader_method: load_file_as_dataframe
+
+INGEST_SCORING_CONFIG:
+  # For different options please read: https://github.com/mlflow/recipes-regression-template#batch-scoring
+  # Use a larger section of the TLC Trip Record Dataset for the batch scoring feature
+  # Specify the format of the dataset
+  using: parquet
+  # TODO: update this field to point to a local filesystem path containing e.g. a sample of your input dataset
+  # for batch inference
+  location: "../data/sample.parquet"
+  loader_method: load_file_as_dataframe
+
+PREDICT_OUTPUT_CONFIG:
+  # For different options please read: https://github.com/mlflow/recipes-regression-template#predict-step
+  # Specify the output format of the batch scoring predict step
+  using: parquet
+  # Specify the output location of the batch scoring predict step
+  location: "./data/sample_output.parquet"

--- a/mlops-poc/training/recipe.yaml
+++ b/mlops-poc/training/recipe.yaml
@@ -1,0 +1,58 @@
+# `recipe.yaml` is the main configuration file for an MLflow Recipe.
+# Required recipe parameters should be defined in this file with either concrete values or
+# variables such as {{ INGEST_DATA_LOCATION }}.
+
+# Variables must be dereferenced in a profile YAML file, located under `profiles/`.
+# See `profiles/local.yaml` for example usage. One may switch among profiles quickly by
+# providing a profile name such as `local` in the Recipe object constructor:
+# `r = Recipe(profile="local")`
+#
+# NOTE: YAML does not support tabs for indentation. Please use spaces and ensure that all YAML
+# files are properly formatted.
+
+recipe: "regression/v1"
+# Specifies the name of the column containing targets / labels for model training and evaluation
+target_col: "fare_amount"
+# Sets the primary metric to use to evaluate model performance. This primary metric is used
+# to sort MLflow Runs corresponding to the recipe in the MLflow Tracking UI
+primary_metric: "root_mean_squared_error"
+steps:
+  ingest: {{INGEST_CONFIG}}
+  split:
+    # Train/validation/test split ratios
+    split_ratios: {{SPLIT_RATIOS|default([0.75, 0.125, 0.125])}}
+    # Specifies the method to use to perform additional processing and cleaning on split datasets
+    post_split_method: process_splits
+  transform:
+    # Specifies the method that defines the data transformations to apply during model inference
+    transformer_method: transformer_fn
+  train:
+    # Specifies the method that defines the estimator type and parameters to use for model training
+    using: custom
+    estimator_method: estimator_fn
+  evaluate:
+    # Sets performance thresholds that a trained model must meet in order to be eligible for
+    # registration to the MLflow Model Registry
+    # TODO: specify pre-deployment validation criteria to apply to fitted models here
+    validation_criteria:
+      - metric: root_mean_squared_error
+        threshold: 10
+      - metric: mean_absolute_error
+        threshold: 50
+      - metric: weighted_mean_squared_error
+        threshold: 20
+  register:
+    # Indicates whether or not a model that fails to meet performance thresholds should still
+    # be registered to the MLflow Model Registry
+    allow_non_validated_model: false
+  ingest_scoring: {{INGEST_SCORING_CONFIG}}
+  predict:
+    output: {{PREDICT_OUTPUT_CONFIG}}
+    # model_uri: "models/model.pkl"
+# Defines custom performance metrics to compute during model training and evaluation
+# TODO: specify custom metrics for model training here, or remove them if not applicable
+custom_metrics:
+    - name: weighted_mean_squared_error
+      # Specifies the name of the function in `steps/custom_metrics.py` to use to compute the metric
+      function: weighted_mean_squared_error
+      greater_is_better: False


### PR DESCRIPTION
Removes the feature store from the training process in our mlops-poc project. The feature store was causing issues with our training process, and we believe that removing it will simplify the training process and improve its reliability.

The changes include updating the CI build to train without the feature store, updating the training job configuration to use the new training process, and removing references to the feature store in the training code.

Overall, this change will improve the reliability of our training process and make it easier to maintain in the future.