### PR TITLE
Refactor training job parameters in prod & staging

### DIFF
--- a/mlops-poc/terraform/prod/training-job.tf
+++ b/mlops-poc/terraform/prod/training-job.tf
@@ -20,8 +20,8 @@ resource "databricks_job" "model_training_job" {
         env = local.env
         # TODO: Update training_data_path
         # training_data_path = "/databricks-datasets/nyctaxi-with-zipcodes/subsampled"
-        experiment_name = databricks_mlflow_experiment.experiment.name
-        model_name      = "${local.env_prefix}mlops-poc-model"
+        # experiment_name = databricks_mlflow_experiment.experiment.name
+        # model_name      = "${local.env_prefix}mlops-poc-model"
       }
     }
 

--- a/mlops-poc/terraform/staging/training-job.tf
+++ b/mlops-poc/terraform/staging/training-job.tf
@@ -19,9 +19,9 @@ resource "databricks_job" "model_training_job" {
       base_parameters = {
         env = local.env
         # TODO: Update training_data_path
-        training_data_path = "/databricks-datasets/nyctaxi-with-zipcodes/subsampled"
-        experiment_name    = databricks_mlflow_experiment.experiment.name
-        model_name         = "${local.env_prefix}mlops-poc-model"
+        # training_data_path = "/databricks-datasets/nyctaxi-with-zipcodes/subsampled"
+        # experiment_name    = databricks_mlflow_experiment.experiment.name
+        # model_name         = "${local.env_prefix}mlops-poc-model"
       }
     }
 

--- a/mlops-poc/validation/notebooks/ModelValidation.py
+++ b/mlops-poc/validation/notebooks/ModelValidation.py
@@ -37,7 +37,6 @@
 # COMMAND ----------
 
 # MAGIC %pip install -r ../../../requirements.txt
-# MAGIC %pip install databricks-feature-store
 
 # COMMAND ----------
 


### PR DESCRIPTION
Disable MLflow experiment and model names for the initial deployment by commenting these fields out. These will be added later when the MLflow experiments are created and ready. The refactored code can now be used as infrastructure code to automate the deployment of Databricks ML job.